### PR TITLE
fix: error when trying to load messages from a non translated language.

### DIFF
--- a/src/plugins/aria.ts
+++ b/src/plugins/aria.ts
@@ -46,13 +46,18 @@ export const AriaPlugin: AriaPluginFunction = (
       locale: 'en-US',
       live: false,
       debounce: 300,
-      onFocusChange: () => {},
+      onFocusChange: () => { },
     };
 
     const base = mergeOptions(defaultOptions, AriaPlugin.globalOptions);
     options = optionsAtMedia(mergeOptions(base, userOptions));
 
-    intl = getIntl(options.locale);
+    try {
+      intl = getIntl(options.locale);
+    } catch (error) {
+      console.warn(error)
+      intl = getIntl(defaultOptions.locale)
+    }
 
     const root = emblaApi.rootNode();
 


### PR DESCRIPTION
This pr catches the error thrown by the message loader and loads the default locale instead.

fixes #2