### PR TITLE
Changing roles to "region" & "group"

### DIFF
--- a/src/plugins/aria.ts
+++ b/src/plugins/aria.ts
@@ -70,7 +70,7 @@ export const AriaPlugin: AriaPluginFunction = (
           : 'off'
         : options.live;
 
-    safelyMountNodeAttr(root, 'role', 'tablist');
+    safelyMountNodeAttr(root, 'role', 'region');
     safelyMountNodeAttr(root, 'aria-live', ariaLive);
     safelyMountNodeAttr(root, 'aria-orientation', ariaOrientation);
     safelyMountNodeAttr(root, 'aria-roledescription', ariaRoleDesc);
@@ -258,7 +258,7 @@ export const AriaPlugin: AriaPluginFunction = (
       const visible = emblaApi.slidesInView().includes(index);
       const localizedRoleDesc = intl.format('slide.roledescription');
 
-      safelyMountNodeAttr(node, 'role', 'tabpanel');
+      safelyMountNodeAttr(node, 'role', 'group');
       safelyMountNodeAttr(node, 'aria-label', localizedLabel);
       safelyMountNodeAttr(node, 'aria-roledescription', localizedRoleDesc);
       safelyMountNodeAttr(node, 'aria-hidden', visible ? 'false' : 'true');


### PR DESCRIPTION
This PR updates the roles that are used for the carousel and slides to match those that are currently used by https://www.w3.org/WAI/ARIA/apg/patterns/carousel/examples/carousel-1-prev-next/.

This came up when implementing this package on a client side.  The ADA auditing firm said:

> **Tabset/Tabpanel 4.1.2 Name, Role, Value (A) Low - Violation 1 Fail**
> _Expected Result:_
> I do not expect to see these TabPanels.
> _Actual Result:_
> The Add To Cart Dialogs contains Carousels that are made up of TabPanels. I do not think that
> this is the correct use of TabPanels.

Also, thank you for releasing this package!